### PR TITLE
Fixed documentation links for generated documentation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
 
               # Documentation
               docs = tsFlake.packages.plutus-ledger-api-typescript.overrideAttrs (_self: (_super: {
+                name = "docs";
                 npmBuildScript = "docs";
                 installPhase =
                   ''

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,6 +8,7 @@
     "./src/PlutusLedgerApi/Runtime/PlutusLedgerApi/AssocMap.ts"
   ],
   "tsconfig": "./src/tsconfig-base.json",
+  "basePath": "./",
   "sourceLinkTemplate": "https://github.com/mlabs-haskell/plutus-ledger-api-typescript/blob/main/{path}#L{line}",
   "disableGit": true,
   "out": "docs"


### PR DESCRIPTION
- It appears that `typedoc` gets confused about the base directory after being processed by nix, so all links will be something like `/build/<hash-garbage>/...` which certainly doesn't exist in the repos

- This fixes this by explicitly setting the `basePath` option to the current working directory